### PR TITLE
Add side effects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "module": "./esm/index.js",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./esm/index.js",


### PR DESCRIPTION
Add side effects to package.json to help bundlers cut unused code. Good with named imports.