### PR TITLE
fix: preserve own `__proto__` properties when deserializing objects

### DIFF
--- a/cjs/deserialize.js
+++ b/cjs/deserialize.js
@@ -41,8 +41,22 @@ const deserializer = ($, _) => {
       }
       case OBJECT: {
         const object = as({}, index);
-        for (const [key, index] of value)
-          object[unpair(key)] = unpair(index);
+        for (const [key, index] of value) {
+          const name = unpair(key);
+          const data = unpair(index);
+          // `object.__proto__ = data` triggers the prototype setter
+          // instead of defining an own property, so the property is
+          // silently dropped on the round-trip; define it explicitly.
+          if (name === '__proto__')
+            Object.defineProperty(object, name, {
+              value: data,
+              writable: true,
+              enumerable: true,
+              configurable: true
+            });
+          else
+            object[name] = data;
+        }
         return object;
       }
       case DATE:

--- a/esm/deserialize.js
+++ b/esm/deserialize.js
@@ -43,8 +43,22 @@ const deserializer = ($, _) => {
       }
       case OBJECT: {
         const object = as({}, index);
-        for (const [key, index] of value)
-          object[unpair(key)] = unpair(index);
+        for (const [key, index] of value) {
+          const name = unpair(key);
+          const data = unpair(index);
+          // `object.__proto__ = data` triggers the prototype setter
+          // instead of defining an own property, so the property is
+          // silently dropped on the round-trip; define it explicitly.
+          if (name === '__proto__')
+            Object.defineProperty(object, name, {
+              value: data,
+              writable: true,
+              enumerable: true,
+              configurable: true
+            });
+          else
+            object[name] = data;
+        }
         return object;
       }
       case DATE:

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,16 @@ assert(withUndefined, '[[2,[[1,2],[3,4],[5,6]]],[0,"foo"],[0,"test"],[0,"bar"],[
 assert(Object.keys(parse(withUndefined)).join(','), 'foo,bar,foobar');
 assert(parse(withUndefined).bar, void 0);
 
+// an own `__proto__` property must survive deserialization rather than
+// being applied as a prototype setter (which silently drops it)
+const withProto = JSON.parse('{"__proto__": 42, "kept": 1}');
+const clonedProto = deserialize(serialize(withProto));
+const protoDescriptor = Object.getOwnPropertyDescriptor(clonedProto, '__proto__');
+assert(!!protoDescriptor, true, 'own __proto__ property should survive deserialize');
+assert(protoDescriptor && protoDescriptor.value, 42, '__proto__ value should be preserved');
+assert(Object.getPrototypeOf(clonedProto), Object.prototype, 'prototype must not be mutated');
+assert(clonedProto.kept, 1, 'sibling property should be preserved');
+
 const date = new Date;
 
 const { buffer } = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);


### PR DESCRIPTION
## The problem

An own property named `__proto__` is dropped when an object is deserialized, even though `serialize` records it and native `structuredClone` preserves it:

```js
import { serialize, deserialize } from '@ungap/structured-clone';

// JSON.parse creates an own enumerable `__proto__` data property
const value = JSON.parse('{"__proto__": 42, "kept": 1}');
Object.getOwnPropertyDescriptor(value, '__proto__'); // { value: 42, … }

// serialize records it faithfully:
JSON.stringify(serialize(value));
// [[2,[[1,2],[3,4]]],[0,"__proto__"],[0,42],[0,"kept"],[0,1]]

const back = deserialize(serialize(value));
Object.getOwnPropertyDescriptor(back, '__proto__'); // undefined  ← dropped
back.kept;                                          // 1

structuredClone(value).__proto__ // 42  ← kept by the platform
```

Objects with a `__proto__` key are common — anything from `JSON.parse('{"__proto__": …}')`, which is exactly the kind of untrusted input that gets cloned.

## Root cause

The `OBJECT` branch of `deserialize` assigns each entry with a computed member:

```js
for (const [key, index] of value)
  object[unpair(key)] = unpair(index);
```

For `key === '__proto__'`, `object['__proto__'] = value` runs the prototype setter rather than creating an own property, so the entry is lost (and a non-object value is simply ignored). `serialize` already emits the key correctly, so only the revival side is affected — this is the inverse of the same `__proto__`-as-setter pitfall.

## Fix

Define the property explicitly when the key is `__proto__`, which creates a genuine own property and never touches the prototype. Every other key keeps the existing fast path. This also fixes `json`'s `parse`, which goes through `deserialize`.

## Test

Added a case to `test/index.js`: an object built with `JSON.parse('{"__proto__": 42, "kept": 1}')` now round-trips with the own `__proto__` property intact (value preserved, prototype unchanged, sibling key preserved). It fails on `main` and passes with the fix; `node test/index.js` is green.
