### PR TITLE
fix: serialize an Invalid Date instead of throwing

### DIFF
--- a/cjs/serialize.js
+++ b/cjs/serialize.js
@@ -119,7 +119,7 @@ const serializer = (strict, json, $, _) => {
         return index;
       }
       case DATE:
-        return as([TYPE, value.toISOString()], value);
+        return as([TYPE, isNaN(value.getTime()) ? EMPTY : value.toISOString()], value);
       case REGEXP: {
         const {source, flags} = value;
         return as([TYPE, {source, flags}], value);

--- a/esm/serialize.js
+++ b/esm/serialize.js
@@ -121,7 +121,7 @@ const serializer = (strict, json, $, _) => {
         return index;
       }
       case DATE:
-        return as([TYPE, value.toISOString()], value);
+        return as([TYPE, isNaN(value.getTime()) ? EMPTY : value.toISOString()], value);
       case REGEXP: {
         const {source, flags} = value;
         return as([TYPE, {source, flags}], value);

--- a/test/index.js
+++ b/test/index.js
@@ -159,4 +159,13 @@ assert(lossy2[3].size, 0);
 assert(JSON.stringify(lossy2[4]), '{}');
 assert(lossy2[5], 'OK');
 
+// an Invalid Date must round-trip like native structuredClone instead of throwing
+const invalidDate = new Date(NaN);
+const invalidViaRecord = deserialize(serialize(invalidDate));
+assert(invalidViaRecord instanceof Date, true);
+assert(Number.isNaN(invalidViaRecord.getTime()), true);
+const invalidViaJSON = parse(stringify(invalidDate));
+assert(invalidViaJSON instanceof Date, true);
+assert(Number.isNaN(invalidViaJSON.getTime()), true);
+
 require('./eval.js');


### PR DESCRIPTION
## Problem

`serialize` (and the `/json` `stringify`) throws on an Invalid Date, even though native `structuredClone` — the API this package ponyfills — clones it without issue:

```js
import {serialize, deserialize} from '@ungap/structured-clone';

structuredClone(new Date(NaN));        // Invalid Date, preserved
deserialize(serialize(new Date(NaN))); // RangeError: Invalid time value
```

An Invalid Date is a legitimate value (e.g. the result of `new Date('not a date')`), so any object graph that happens to contain one crashes the clone. The README documents no Invalid-Date caveat (the only stated limitation is unsupported array elements becoming `null`).

## Cause

`Date.prototype.toISOString()` throws a `RangeError` when the date's time value is `NaN`, and the `DATE` case calls it unconditionally:

```js
case DATE:
  return as([TYPE, value.toISOString()], value);
```

The deserialize side already handles it: it does `new Date(value)`, which faithfully revives an Invalid Date.

## Fix

Store an empty string for an Invalid Date:

```js
case DATE:
  return as([TYPE, isNaN(value.getTime()) ? EMPTY : value.toISOString()], value);
```

`EMPTY` (`''`) is chosen deliberately over `NaN`/`getTime()`: it is JSON-safe, so the `/json` path round-trips too (`NaN` would serialize to `null`, and `new Date(null)` revives to epoch 0), and `new Date('')` revives to an Invalid Date — matching the deserialize side. Valid dates are unaffected.

## Tests

Added round-trip assertions for an Invalid Date on both the record API and the `/json` API. They throw on `main` and pass with the fix; the rest of the suite is unchanged.

(The minified `structured-json.js` browser bundle is a build artifact regenerated by `npm run build`, so it is left out of this diff.)