### PR TITLE
fix: keep -0 and +0 distinct through serialize/deserialize

### DIFF
--- a/cjs/serialize.js
+++ b/cjs/serialize.js
@@ -47,14 +47,21 @@ const shouldSkip = ([TYPE, type]) => (
 
 const serializer = (strict, json, $, _) => {
 
+  // `$` memoizes seen values to preserve shared references and handle cycles,
+  // but it is a Map and Map keys use SameValueZero, which treats -0 and +0 as
+  // the same key. Negative zero must skip the memo so it is never conflated
+  // with +0, which native structuredClone (and the default clone) keep apart.
+  const memoizable = value => !Object.is(value, -0);
+
   const as = (out, value) => {
     const index = _.push(out) - 1;
-    $.set(value, index);
+    if (memoizable(value))
+      $.set(value, index);
     return index;
   };
 
   const pair = value => {
-    if ($.has(value))
+    if (memoizable(value) && $.has(value))
       return $.get(value);
 
     let [TYPE, type] = typeOf(value);

--- a/esm/serialize.js
+++ b/esm/serialize.js
@@ -49,14 +49,21 @@ const shouldSkip = ([TYPE, type]) => (
 
 const serializer = (strict, json, $, _) => {
 
+  // `$` memoizes seen values to preserve shared references and handle cycles,
+  // but it is a Map and Map keys use SameValueZero, which treats -0 and +0 as
+  // the same key. Negative zero must skip the memo so it is never conflated
+  // with +0, which native structuredClone (and the default clone) keep apart.
+  const memoizable = value => !Object.is(value, -0);
+
   const as = (out, value) => {
     const index = _.push(out) - 1;
-    $.set(value, index);
+    if (memoizable(value))
+      $.set(value, index);
     return index;
   };
 
   const pair = value => {
-    if ($.has(value))
+    if (memoizable(value) && $.has(value))
       return $.get(value);
 
     let [TYPE, type] = typeOf(value);

--- a/test/index.js
+++ b/test/index.js
@@ -168,4 +168,17 @@ const invalidViaJSON = parse(stringify(invalidDate));
 assert(invalidViaJSON instanceof Date, true);
 assert(Number.isNaN(invalidViaJSON.getTime()), true);
 
+// -0 and +0 must round-trip distinctly like native structuredClone, even when
+// both appear in the same value. The serialize memo is a Map, whose keys use
+// SameValueZero, so without care +0 and -0 collapse onto a single record.
+const zeros = deserialize(serialize([-0, 0]));
+assert(zeros[0], -0, `expected -0 at [0], got ${zeros[0]}`);
+assert(zeros[1], 0, `expected +0 at [1], got ${zeros[1]}`);
+const zerosRev = deserialize(serialize([0, -0]));
+assert(zerosRev[0], 0, `expected +0 at [0], got ${zerosRev[0]}`);
+assert(zerosRev[1], -0, `expected -0 at [1], got ${zerosRev[1]}`);
+const zerosObj = deserialize(serialize({neg: -0, pos: 0}));
+assert(zerosObj.neg, -0, `expected -0 for neg, got ${zerosObj.neg}`);
+assert(zerosObj.pos, 0, `expected +0 for pos, got ${zerosObj.pos}`);
+
 require('./eval.js');


### PR DESCRIPTION
`serialize` memoizes every value it has seen in a `Map` so shared references and cycles round-trip as one record. `Map` keys use SameValueZero, which treats `-0` and `+0` as the same key, so when both appear in one value the second one reuses the first one's record. After `deserialize` they come back with a single sign:

```js
const {serialize, deserialize} = require('@ungap/structured-clone');

deserialize(serialize([-0, 0]));        // [-0, -0]   (expected [-0, 0])
deserialize(serialize([0, -0]));        // [0, 0]     (expected [0, -0])
deserialize(serialize({neg: -0, pos: 0})); // {neg: -0, pos: -0}
```

Native `structuredClone` and this module's own default `clone` (which copies values directly instead of going through the memo) both keep the two zeros distinct, so `serialize`/`deserialize` is the only path that loses the difference.

The fix skips the memo for negative zero only, so `-0` can never share a record with `+0`. Every other value memoizes exactly as before, so reference sharing, cycles and the existing serialized output are unchanged. A `Set` still collapses `-0`/`+0` into one element, matching native, because that happens in the `Set` itself and not in the memo.

Added a round-trip test alongside the Invalid Date one. The suite passes; reverting the `serialize.js` change makes the new test fail.
